### PR TITLE
_pkgdown.yml: generalize the reference to GRASS versions

### DIFF
--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -20,7 +20,7 @@ reference:
     - starts_with("gdal_")
 
   - title: GRASS
-    desc: Algorithms provided by GRASS version 7.x.x.
+    desc: Algorithms provided by GRASS GIS.
     contents:
     - starts_with("grass7_")
 


### PR DESCRIPTION
The 'grass7' labels of the algorithms are misleading; they're effectively using GRASS 8 if the latter is installed. In near future, the 'grass7' provider label will be replaced by a 'grass' label.